### PR TITLE
fix: update Chicago Taxi Dataset URL to Zenodo

### DIFF
--- a/lesson-3-awkward/project-1-taxi.ipynb
+++ b/lesson-3-awkward/project-1-taxi.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "and those levels have variable lengths: each taxi takes a different number of trips and each trip has a different number of points.\n",
     "\n",
-    "Our dataset is formatted as a 611 MB [Apache Parquet](https://parquet.apache.org/) file, provided here: [https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet](https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet)."
+    "Our dataset is formatted as a 611 MB [Apache Parquet](https://parquet.apache.org/) file, provided here: [https://zenodo.org/records/14537442/files/chicago-taxi.parquet](https://zenodo.org/records/14537442/files/chicago-taxi.parquet)."
    ]
   },
   {
@@ -120,7 +120,7 @@
    "outputs": [],
    "source": [
     "# taxi_file = \"/home/gwatts/code/iris-hep/2024-12-20-hsf-india-tutorial-kolkata/chicago-taxi.parquet\"\n",
-    "taxi_file = \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\"\n",
+    "taxi_file = \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\"\n",
     "\n",
     "taxi = ak.from_parquet(\n",
     "    taxi_file,\n",

--- a/lesson-3-awkward/solutions-1-taxi.ipynb
+++ b/lesson-3-awkward/solutions-1-taxi.ipynb
@@ -111,7 +111,7 @@
    ],
    "source": [
     "taxi = ak.from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\",\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\",\n",
     "    columns=[\"trip.km\", \"trip.begin.l*\", \"trip.path.*\"],\n",
     "    row_groups=[0],\n",
     ")\n",


### PR DESCRIPTION
Since we use this dataset a lot, I created a [Zenodo page](https://doi.org/10.5281/zenodo.14537441) for it.

[![](https://zenodo.org/badge/DOI/10.5281/zenodo.14537442.svg)](https://doi.org/10.5281/zenodo.14537441)

I'll need to delete the copy on AWS, so please accept this PR to update all of your URL references. Thanks!